### PR TITLE
Updated change log for OL9 docker images for January 24 and January 25.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
-## 2024-01-17-2024
+## 2024-01-25
+* Update `oraclelinux:9` and `oraclelinux:9-slim` for `amd64` and `arm64v8`:
+  *[ELSA-2024-0463 - rpm security update](https://linux.oracle.com/errata/ELSA-2024-0463.html)
+    * [CVE-2021-35937](https://linux.oracle.com/cve/CVE-2021-35937.html)
+    * [CVE-2021-35938](https://linux.oracle.com/cve/CVE-2021-35938.html)
+    * [CVE-2021-35939](https://linux.oracle.com/cve/CVE-2021-35939.html)
+  *[ELSA-2024-0466 - python3.9 security update](https://linux.oracle.com/errata/ELSA-2024-0466.html)
+    * [CVE-2023-27043](https://linux.oracle.com/cve/CVE-2023-27043.html)
+  *[ELSA-2024-0465 - sqlite security update](https://linux.oracle.com/errata/ELSA-2024-0465.html)
+    * [CVE-2023-7104](https://linux.oracle.com/cve/CVE-2023-7104.html)
+
+* <https://github.com/docker-library/official-images/pull/16137>
+
+## 2024-01-24
+* Update `oraclelinux:9` and `oraclelinux:9-slim` for `amd64` and `arm64v8`:
+  *[ELSA-2024-0310 - openssl security update](https://linux.oracle.com/errata/ELSA-2024-0310.html)
+    * [CVE-2023-5363](https://linux.oracle.com/cve/CVE-2023-5363.html)
+
+* <https://github.com/docker-library/official-images/pull/16128>
+`
+## 2024-01-17
 * Update `oraclelinux:7`, `oraclelinux:7-slim`, `oraclelinux:7-slim-fips`, `oraclelinux:8`, `oraclelinux:8-slim`, `oraclelinux:8-slim-fips`, `oraclelinux:9`, `oraclelinux:9-slim` for `amd64` and `arm64v8`:
 
 * Republish all images for `tzdata-2023d-1`:
@@ -23,7 +43,7 @@
 
 * <https://github.com/docker-library/official-images/pull/16070>
 
-## 2023-12-20-2023
+## 2023-12-20
 * Update `oraclelinux:8`, `oraclelinux:8-slim`, `oraclelinux:8-slim-fips` for `amd64` and `arm64v8`:
   *[ELSA-2023-7877 - openssl security update](https://linux.oracle.com/errata/ELSA-2023-7877.html)
       * [CVE-2023-3446](https://linux.oracle.com/cve/CVE-2023-3446.html)
@@ -32,7 +52,7 @@
 
 * <https://github.com/docker-library/official-images/pull/15949>
 
-## 2023-12-14-2023
+## 2023-12-14
 * Update `oraclelinux:7`, `oraclelinux:7-slim`, `oraclelinux:7-slim-fips`, `oraclelinux:9`, `oraclelinux:9-slim` for `amd64` and `arm64v8`:
   *[ELSA-2023-7743 - curl security update](https://linux.oracle.com/errata/ELSA-2023-7743.html)
       * [CVE-2022-43552](https://linux.oracle.com/cve/CVE-2022-43552.html)
@@ -41,7 +61,7 @@
 
 * <https://github.com/docker-library/official-images/pull/15914>
 
-## 2023-12-06-2023
+## 2023-12-06
 * Release Oracle Linux 8 Update 9 for `amd64` and `arm64v8`:
   * Update `oraclelinux:8` to Update 9
   * Update `oraclelinux:8-slim` to Update 9
@@ -49,28 +69,28 @@
 
 * <https://github.com/docker-library/official-images/pull/15845>
 
-## 2023-11-16-2023
+## 2023-11-16
 * Release Oracle Linux 9 Update 3 for `amd64` and `arm64v8`:
   * Update `oraclelinux:9` to Update 3
   * Update `oraclelinux:9-slim` to Update 3
 
 * <https://github.com/docker-library/official-images/pull/15735>
 
-## 2023-11-13-2023
+## 2023-11-13
 * Update `oraclelinux:7`, `oraclelinux:7-slim` and `oraclelinux:7-slim-fips` for `amd64` and `arm64v8`:
   *[ELSA-2023-6885 - python security update](https://linux.oracle.com/errata/ELSA-2023-6885.html)
       * [CVE-2023-40217](https://linux.oracle.com/cve/CVE-2023-40217.html)
 
 * <https://github.com/docker-library/official-images/pull/15711>
 
-## 2023-10-27-2023
+## 2023-10-27
 * Update `oraclelinux:8` for `amd64` and `arm64v8`:
   *[ELSA-2023-5997 - python3 security update](https://linux.oracle.com/errata/ELSA-2023-5997.html)
       * [CVE-2023-40217](https://linux.oracle.com/cve/CVE-2023-40217.html)
 
 * <https://github.com/docker-library/official-images/pull/15633>
 
-## 2023-10-20-2023
+## 2023-10-20
 * Update `oraclelinux:9` and `oraclelinux:9-slim` for `amd64` and `arm64v8`:
   *[ELSA-2023-5462 - python3.9 security update](https://linux.oracle.com/errata/ELSA-2023-5462.html)
       * [CVE-2023-40217](https://linux.oracle.com/cve/CVE-2023-40217.html)


### PR DESCRIPTION
Includes the following:
ELSA-2024-0463/CVE-2021-35937/CVE-2021-35938/CVE-2021-35939
ELSA-2024-0466/CVE-2023-27043
ELSA-2024-0465/CVE-2023-7104
ELSA-2024-0310/CVE-2023-5363

Also cleaned up extra -YYYY at the end of recent datestamps.