### PR TITLE
Updated changelog for ELSA-2025-1301/CVE-2020-11023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 2025-02-13
+* Update `oraclelinux:8` , `oraclelinux:8-slim` and `oraclelinux:8-slim-fips` for `amd64` and `arm64v8`:
+  * [ELSA-2025-1301 - gcc security update](https://linux.oracle.com/errata/ELSA-2025-1301.html)
+    * [CVE-2020-11023](https://linux.oracle.com/cve/CVE-2020-11023.html)
+* <https://github.com/docker-library/official-images/pull/18457>
+
 ## 2025-02-05
 * Update `oraclelinux:9` , `oraclelinux:9-slim` and `oraclelinux:9-slim-fips` for `amd64` and `arm64v8`:
   * [ELSA-2025-0925 - bzip2 security update](https://linux.oracle.com/errata/ELSA-2025-0925.html)


### PR DESCRIPTION
Updated change log for:
ELSA-2025-1301/CVE-2020-11023

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
