### PR TITLE
Updated changelog for ELSA-2025-1517/CVE-2022-49043

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 2025-02-19
+* Update `oraclelinux:8` , `oraclelinux:8-slim` and `oraclelinux:8-slim-fips` for `amd64` and `arm64v8`:
+  * [ELSA-2025-1517 - libxml2 security update](https://linux.oracle.com/errata/ELSA-2025-1517.html)
+    * [CVE-2022-49043](https://linux.oracle.com/cve/CVE-2022-49043.html)
+* <https://github.com/docker-library/official-images/pull/18489>
+
 ## 2025-02-14
 * Update `oraclelinux:9` , `oraclelinux:9-slim` and `oraclelinux:9-slim-fips` for `amd64` and `arm64v8`:
   * [ELSA-2025-1346 - gcc security update](https://linux.oracle.com/errata/ELSA-2025-1346.html)


### PR DESCRIPTION
Updated change log for:
ELSA-2025-1517/CVE-2022-49043

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
