### PR TITLE
Updated changelog for ELSA-2025-12010/CVE-2025-6965

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 ## 2025-07-29
+* Update `oraclelinux:8` , `oraclelinux:8-slim` and `oraclelinux:8-slim-fips` for `amd64` and `arm64v8`:
+  * [ELSA-2025-12010 - sqlite security update](https://linux.oracle.com/errata/ELSA-2025-12010.html)
+    * [CVE-2025-6965](https://linux.oracle.com/cve/CVE-2025-6965.html)
+* <https://github.com/docker-library/official-images/pull/19565>
+
+## 2025-07-29
 * Update `oraclelinux:9` , `oraclelinux:9-slim` and `oraclelinux:9-slim-fips` for `amd64` and `arm64v8`:
   * [ELSA-2025-11992 - sqlite security update](https://linux.oracle.com/errata/ELSA-2025-11992.html)
     * [CVE-2025-6965](https://linux.oracle.com/cve/CVE-2025-6965.html)


### PR DESCRIPTION
Updated change log for:
ELSA-2025-12010/CVE-2025-6965

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
