### PR TITLE
Updated changelog for ELSA-2025-12450/CVE-2025-7425

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 ## 2025-08-01
+* Update `oraclelinux:8` , `oraclelinux:8-slim` and `oraclelinux:8-slim-fips` for `amd64` and `arm64v8`:
+  * [ELSA-2025-12450 - libxml2 security update](https://linux.oracle.com/errata/ELSA-2025-12450.html)
+    * [CVE-2025-7425](https://linux.oracle.com/cve/CVE-2025-7425.html)
+* <https://github.com/docker-library/official-images/pull/19598>
+
+## 2025-08-01
 * Update `oraclelinux:9` , `oraclelinux:9-slim` and `oraclelinux:9-slim-fips` for `amd64` and `arm64v8`:
   * [ELSA-2025-12447 - libxml2 security update](https://linux.oracle.com/errata/ELSA-2025-12447.html)
     * [CVE-2025-7425](https://linux.oracle.com/cve/CVE-2025-7425.html)


### PR DESCRIPTION
Updated change log for:
ELSA-2025-12450/CVE-2025-7425

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
