### PR TITLE
Updated changelog for ELSA-2026-8492/CVE-2026-4424
ELSA-2026-8492/CVE-2026-4424
ELSA-2026-8534/CVE-2026-4424/CVE-2026-5121
ELSA-2026-8492/CVE-2026-4424
ELSA-2026-8534/CVE-2026-4424/CVE-2026-5121
ELSA-2026-8510/CVE-2026-4424/CVE-2026-5121

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,25 @@
 # Changelog
+## 2026-04-17
+* Update `oraclelinux:10` and `oraclelinux:10-slim` for `amd64` and `arm64v8`:
+  * [ELSA-2026-8492 - libarchive security update](https://linux.oracle.com/errata/ELSA-2026-8492.html)
+    * [CVE-2026-4424](https://linux.oracle.com/cve/CVE-2026-4424.html)
+* Update `oraclelinux:8` , `oraclelinux:8-slim` and `oraclelinux:8-slim-fips` for `amd64` and `arm64v8`:
+  * [ELSA-2026-8492 - libarchive security update](https://linux.oracle.com/errata/ELSA-2026-8492.html)
+    * [CVE-2026-4424](https://linux.oracle.com/cve/CVE-2026-4424.html)
+  * [ELSA-2026-8534 - libarchive security update](https://linux.oracle.com/errata/ELSA-2026-8534.html)
+    * [CVE-2026-4424](https://linux.oracle.com/cve/CVE-2026-4424.html)
+    * [CVE-2026-5121](https://linux.oracle.com/cve/CVE-2026-5121.html)
+* Update `oraclelinux:9` , `oraclelinux:9-slim` and `oraclelinux:9-slim-fips` for `amd64` and `arm64v8`:
+  * [ELSA-2026-8492 - libarchive security update](https://linux.oracle.com/errata/ELSA-2026-8492.html)
+    * [CVE-2026-4424](https://linux.oracle.com/cve/CVE-2026-4424.html)
+  * [ELSA-2026-8534 - libarchive security update](https://linux.oracle.com/errata/ELSA-2026-8534.html)
+    * [CVE-2026-4424](https://linux.oracle.com/cve/CVE-2026-4424.html)
+    * [CVE-2026-5121](https://linux.oracle.com/cve/CVE-2026-5121.html)
+  * [ELSA-2026-8510 - libarchive security update](https://linux.oracle.com/errata/ELSA-2026-8510.html)
+    * [CVE-2026-4424](https://linux.oracle.com/cve/CVE-2026-4424.html)
+    * [CVE-2026-5121](https://linux.oracle.com/cve/CVE-2026-5121.html)
+* <https://github.com/docker-library/official-images/pull/21269>
+
 ## 2026-04-16
 * Update `oraclelinux:8` for `amd64` and `arm64v8`:
   * [ELSA-2026-8352 - bind security update](https://linux.oracle.com/errata/ELSA-2026-8352.html)


### PR DESCRIPTION
Updated change log for:
ELSA-2026-8492/CVE-2026-4424
ELSA-2026-8492/CVE-2026-4424
ELSA-2026-8534/CVE-2026-4424/CVE-2026-5121
ELSA-2026-8492/CVE-2026-4424
ELSA-2026-8534/CVE-2026-4424/CVE-2026-5121
ELSA-2026-8510/CVE-2026-4424/CVE-2026-5121

Signed-off-by: Mark Will <mark.will@oracle.com>
